### PR TITLE
Fix for plasma 6.4

### DIFF
--- a/contents/ui/FullRepresentation.qml
+++ b/contents/ui/FullRepresentation.qml
@@ -513,14 +513,6 @@ Item {
 
                             }
                         }
-                        NightLightControl {
-                            id: control
-
-                            readonly property bool transitioning: control.currentTemperature != control.targetTemperature
-                            readonly property bool hasSwitchingTimes: control.mode != 3
-                            readonly property bool togglable: nightLight || !control.inhibited || control.inhibitedFromApplet
-
-                        }
                     }
                     Item {
                         id: weatherToggle


### PR DESCRIPTION
Fixes #10

For some reason the NightLightControl crashed the widget on plasma 6.4.
As mentioned in #10 I fixed it by removing the control as I found no other reference to it in the project space.

I'm no expert in plasma widgets so please tell me if there was a better solution for this and I'm happy to thinker with that.