### PR TITLE
Add Turkish translation (tr.po)

### DIFF
--- a/translate/tr.po
+++ b/translate/tr.po
@@ -1,0 +1,195 @@
+# Translation of plasma control hub in LANGUAGE
+# Copyright (C) 2024
+# This file is distributed under the same license as the plasma control hub package.
+#
+# SPDX-FileCopyrightText: 2025 tunahan <tunahanyrd@gmail.com>
+msgid ""
+msgstr ""
+"Project-Id-Version: plasma control hub\n"
+"Report-Msgid-Bugs-To: https://store.kde.org/p/2139890/\n"
+"POT-Creation-Date: 2024-12-01 16:59-0300\n"
+"PO-Revision-Date: 2025-07-14 10:50+0300\n"
+"Last-Translator: tunahan <tunahanyrd@gmail.com>\n"
+"Language-Team: Turkish <kde-l10n-tr@kde.org>\n"
+"Language: tr_TR\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Lokalize 25.04.3\n"
+
+#: ../contents/ui/UserInfo.qml
+msgid "Hi"
+msgstr "Selam"
+
+#: ../contents/ui/FullRepresentation.qml
+msgid "Settings"
+msgstr "Ayarlar"
+
+#: ../contents/ui/FullRepresentation.qml
+msgid "System Settings"
+msgstr "Sistem Ayarları"
+
+#: ../contents/ui/FullRepresentation.qml
+msgid "Volume"
+msgstr "Ses"
+
+#: ../contents/ui/FullRepresentation.qm
+msgid "Bluetooth"
+msgstr "Bluetooth"
+
+#: ../contents/ui/FullRepresentation.qm
+msgid "Network"
+msgstr "Ağ"
+
+#: ../contents/ui/FullRepresentation.qm
+msgid "DND"
+msgstr "R.E."
+
+#: ../contents/ui/js/funcs.js
+msgid "Disabled"
+msgstr "Devre Dışı"
+
+#: ../contents/ui/js/funcs.js
+msgid "Unavailable"
+msgstr "Ulaşılamıyor"
+
+#: ../contents/ui/js/funcs.js
+msgid "Offline"
+msgstr "Çevrim dışı"
+
+#: ../contents/ui/js/funcs.js
+msgid "Not Connected"
+msgstr "Bağlı değil"
+
+#: ../contents/ui/Brightness.qml
+msgid "Brightness"
+msgstr "Parlaklık"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Clear"
+msgstr "AÇık hava"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Mainly clear"
+msgstr "Genellikle açık"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Partly cloudy"
+msgstr "Parçalı Bulutlı"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Overcast"
+msgstr "Kapalı Hava"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Drizzle light intensity"
+msgstr "Hafif çiseleme"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Drizzle moderate intensity"
+msgstr "Orta şiddetli çiseleme"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Drizzle dense intensity"
+msgstr "Yoğun çiseleme"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Freezing Drizzle light intensity"
+msgstr "Hafif donan çiseleme"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Freezing Drizzle dense intensity"
+msgstr "Yoğun donan çiseleme"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Rain slight intensity"
+msgstr "Hafif yağmur"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Rain moderate intensity"
+msgstr "Orta şiddette yağmur"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Rain heavy intensity"
+msgstr "Yoğun yağmur"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Freezing Rain light intensity"
+msgstr "Hafif donan yağmur"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Freezing Rain heavy intensity"
+msgstr "Şiddetli donan yağmur"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Snowfall slight intensity"
+msgstr "Hafif kar yağışı"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Snowfall moderate intensity"
+msgstr "Orta şiddetli kar yağışı"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Snowfall heavy intensity"
+msgstr "Yoğun kar yağışı"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Snow grains"
+msgstr "Buz tanecikleri"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Rain showers slight"
+msgstr "Hafif sağanak yağmur"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Rain showers moderate"
+msgstr "Orta şiddette sağanak yağmur"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Rain showers violent"
+msgstr "Şiddetli sağanak yağmur"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Snow showers slight"
+msgstr "Hafif kar yağışı"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Snow showers heavy"
+msgstr "Yoğun kar yağışı"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Thunderstorm"
+msgstr "Gökgürültülü fırtına"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Thunderstorm with slight hail"
+msgstr "Hafif dolulu gök gürültülü fırtına"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Thunderstorm with heavy hail"
+msgstr "Yoğun dolulu gök gürültülü fırtına"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Cloudy"
+msgstr "Bulutlu"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Drizzle"
+msgstr "Çiseleme"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Rain"
+msgstr "Yağmur"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Snow"
+msgstr "Kar"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Showers"
+msgstr "Sağanak"
+
+#: ../contents/ui/component/WeatherData.qml
+msgid "Storm"
+msgstr "Fırtına"


### PR DESCRIPTION
This pull request adds Turkish localization to the Plasma Control Hub plasmoid.

Translated all strings from `template.pot` into Turkish  
Verified consistency and clarity across weather and system terms  
File added: `translate/tr.po`

Examples:
- "Clear" → "Açık hava"
- "DND" → "R.E."
- "Snow grains" → "Buz tanecikleri"

Let me know if you’d like adjustments or if further testing is needed.

> Tr: Bu PR, Plasma Control Hub için tam Türkçe çeviri dosyasını (`tr.po`) ekler. Tüm ifadeler `template.pot` baz alınarak çevrilmiştir. Teknik ve kullanıcı dostu ifadeler tercih edilmiştir.

